### PR TITLE
250603 58621 vera wade credit variations

### DIFF
--- a/front-end/src/pages/Projects/VariationCreate.jsx
+++ b/front-end/src/pages/Projects/VariationCreate.jsx
@@ -302,14 +302,14 @@ const VariationCreate = () => {
                   <div className="row mb-3">
                     <div className="col-md-6">
                       <label className="form-label">Variation Cost *</label>
-                      <div className="row">
+                      <div className="input-group mb-2 align-items-center">
                         <label
                           htmlFor="type"
                           className="col">
-                          type:
+                          Type:
                         </label>
                         <select
-                          className="form-select col justify-content-start"
+                          className="form-select col"
                           name="type"
                           id="type"
                           onChange={(e) => {

--- a/front-end/src/pages/Projects/VariationCreate.jsx
+++ b/front-end/src/pages/Projects/VariationCreate.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { useParams, useNavigate, replace } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import { useProject } from "../../contexts/ProjectContext";
 import Header from "../../components/Header/index";
 import "bootstrap/dist/css/bootstrap.min.css";
@@ -15,7 +15,7 @@ const VariationCreate = () => {
   const [variationData, setVariationData] = useState(createEmptyVariation());
   const [formErrors, setFormErrors] = useState({});
   const [formLocked, setFormLocked] = useState(false);
-  
+
   const { lockForm } = useFormLock(formLocked, `/projects/${projectId}`);
 
   useEffect(() => {
@@ -157,13 +157,12 @@ const VariationCreate = () => {
 
     const result = await addVariation(projectId, formattedData);
 
-                if (result.success) {
-                  setFormLocked(true);
-                  lockForm(`/projects/${projectId}`);
-                  navigate(`/projects/${projectId}/variations/${result.data.variationId}/?firstTime=true`);
-                }
-              };
-
+    if (result.success) {
+      setFormLocked(true);
+      lockForm(`/projects/${projectId}`);
+      navigate(`/projects/${projectId}/variations/${result.data.variationId}/?firstTime=true`);
+    }
+  };
 
   const handleCancel = () => {
     navigate(`/projects/${projectId}`);
@@ -303,22 +302,35 @@ const VariationCreate = () => {
                   <div className="row mb-3">
                     <div className="col-md-6">
                       <label className="form-label">Variation Cost *</label>
-                      <div>
-                        <label htmlFor="type">type:</label>
-                        <select name="type" id="type" onChange={
-                          (e) => {
+                      <div className="row">
+                        <label
+                          htmlFor="type"
+                          className="col">
+                          type:
+                        </label>
+                        <select
+                          className="form-select col justify-content-start"
+                          name="type"
+                          id="type"
+                          onChange={(e) => {
                             setVariationData((prev) => ({
                               ...prev,
-                              variationType: e.target.value
+                              variationType: e.target.value,
                             }));
-                          }
-                        }>
-                          <option selected value="debit">debit</option>
+                          }}>
+                          <option
+                            selected
+                            value="debit">
+                            debit
+                          </option>
                           <option value="credit">credit</option>
                         </select>
                       </div>
                       <div className="input-group">
-                        <span className="input-group-text">$</span>
+                        <span className="input-group-text">
+                          {variationData.variationType === "credit" && <span>-</span>}$
+                        </span>
+
                         <input
                           type="text"
                           className={`form-control ${formErrors.cost ? "is-invalid" : ""}`}
@@ -413,7 +425,7 @@ const VariationCreate = () => {
                     <button
                       type="submit"
                       className="btn btn-primary"
-                      style={{color: "white"}}
+                      style={{ color: "white" }}
                       disabled={loading}>
                       {loading ? (
                         <>

--- a/front-end/src/pages/Projects/VariationCreate.jsx
+++ b/front-end/src/pages/Projects/VariationCreate.jsx
@@ -58,6 +58,9 @@ const VariationCreate = () => {
 
     // Fallback to 0 if cost is invalid
     if (isNaN(cleanCost)) return currentProject.currentContractPrice;
+    if (variationData.variationType === "credit") {
+      return currentProject.currentContractPrice - cleanCost;
+    }
 
     return currentProject.currentContractPrice + cleanCost;
   };
@@ -300,6 +303,20 @@ const VariationCreate = () => {
                   <div className="row mb-3">
                     <div className="col-md-6">
                       <label className="form-label">Variation Cost *</label>
+                      <div>
+                        <label htmlFor="type">type:</label>
+                        <select name="type" id="type" onChange={
+                          (e) => {
+                            setVariationData((prev) => ({
+                              ...prev,
+                              variationType: e.target.value
+                            }));
+                          }
+                        }>
+                          <option selected value="debit">debit</option>
+                          <option value="credit">credit</option>
+                        </select>
+                      </div>
                       <div className="input-group">
                         <span className="input-group-text">$</span>
                         <input


### PR DESCRIPTION
**One more ticket closed**

The variations can now be selected as debit or credit. It means we deduct from the final variation cost if `variationType` is `credit`.

_A thing to review:_ do we want to highlight the debit/credit in red/green?

_Note:_ maybe change the yellow colour of the projected new price? It's difficult to read.


<img width="1008" height="471" alt="Screenshot 2025-09-03 at 11 18 16" src="https://github.com/user-attachments/assets/b8a45977-11e0-4600-909f-860f0cc036da" />

