### PR TITLE
PR for Review - feat: Auto extend project end date with sum of approved variation delays

### DIFF
--- a/back-end/controllers/projectController.js
+++ b/back-end/controllers/projectController.js
@@ -262,7 +262,7 @@ export const addVariation = async (req, res) => {
     // Add variation to project
     project.variations.push(variationData);
 
-    // The pre-save middleware will automatically calculate the new contract price
+    // The pre-save middleware will automatically calculate the new contract price and end date
     const updatedProject = await project.save();
 
     // Get the newly created variation
@@ -362,7 +362,7 @@ export const updateVariation = async (req, res) => {
       project.variations[variationIndex][key] = updateData[key];
     });
 
-    // The pre-save middleware will automatically recalculate the contract price
+    // The pre-save middleware will automatically recalculate the contract price and end date
     const updatedProject = await project.save();
 
     res.status(200).json(updatedProject);


### PR DESCRIPTION
Project Expected End date is calculated based on sum of approved variation delays. This accounts for if a new variation is added, a variation is updated and a variation is deleted. It also accounts for variations that have a negative effect on delays.

projectSchema middleware has been modified to calculated the expected end date when CRUD is carried out on variations.

*** note *** 

Assumed business logic for variation to contribute towards extending project end date requires variation's status to be 'approved'. Only variations that are 'approved' contribute toward the expected end date. Happy to make changes to this if this is NOT the case.